### PR TITLE
CTEM-8, 10 & 11: Beneficiary creation, Retrieve Beneficiary & Beneficiary update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,8 +27,8 @@ function App() {
         <Route path="/forget-password" element={<ForgetMeNot />} />
         <Route path="/view-admin" element={<Admin />} />
         <Route path="/view-profile" element={<YourProfile />} />
-        <Route path="/view-beneficiary" element={<BeneficiaryProfile />} />
-        <Route path="/view-volunteer" element={<VolunteerProfile />} />
+        <Route path="/view-beneficiary/:docId" element={<BeneficiaryProfile />} />
+        <Route path="/view-volunteer/:docId" element={<VolunteerProfile />} />
         <Route path="/create-volunteer-profile" element={<VolunteerProfileCreation />} />
         <Route path="/create-beneficiary-profile" element={<BeneficiaryProfileCreation />} />
         <Route path="/view-profile-list" element={<Temp />} />

--- a/src/components/GuardianCard.tsx
+++ b/src/components/GuardianCard.tsx
@@ -1,4 +1,20 @@
-function GuardianCard({formState=false}: {formState : (boolean | null);}){
+import type { Guardian } from "../models/guardianType";
+
+function GuardianCard(
+    {formState=false, 
+        index, 
+        guardians, 
+        setGuardians}: 
+    {formState : (boolean | null),
+        index: number,
+        guardians: Guardian[],
+        setGuardians: React.Dispatch<React.SetStateAction<Guardian[]>>
+}){
+    const changeField = (field: string, val: string) => {
+        const upd = [...guardians]
+        upd[index] = { ...upd[index], [field]: val }
+        setGuardians(upd)
+    }
     return (
         <>
         <div className="flex flex-row items-center w-full text-white border-x border-t rounded-t-sm border-[#254151] bg-[#3EA08D] px-3">
@@ -9,6 +25,8 @@ function GuardianCard({formState=false}: {formState : (boolean | null);}){
             id="ParentName"
             className="w-full bg-[#3e907f] text-white px-3 py-2 font-[Montserrat] border border-[#254151] m-1 rounded-sm"
             readOnly={formState ?? true}
+            value={guardians[index].name}
+            onChange={e => changeField('name', e.target.value)}
             />
         </div>
         <div className="flex flex-row items-center w-full text-white border-x border-[#254151] bg-[#3EA08D] px-3">
@@ -19,6 +37,8 @@ function GuardianCard({formState=false}: {formState : (boolean | null);}){
             id="Relation"
             className="w-full bg-[#3e907f] text-white px-3 py-2 font-[Montserrat] border border-[#254151] m-1 rounded-sm"
             readOnly={formState ?? true}
+            value={guardians[index].relation}
+            onChange={e => changeField('relation', e.target.value)}
             />
         </div>
         <div className="flex flex-row items-center w-full text-white border-x border-[#254151] bg-[#3EA08D] px-3">
@@ -29,6 +49,8 @@ function GuardianCard({formState=false}: {formState : (boolean | null);}){
             id="email"
             className="w-full bg-[#3e907f] text-white px-3 py-2 font-[Montserrat] border border-[#254151] m-1 rounded-sm"
             readOnly={formState ?? true}
+            value={guardians[index].email}
+            onChange={e => changeField('email', e.target.value)}
             />
         </div>
         <div className="flex flex-row items-center w-full text-white border-b border-x rounded-b-sm border-[#254151] bg-[#3EA08D] px-3">
@@ -39,6 +61,8 @@ function GuardianCard({formState=false}: {formState : (boolean | null);}){
             id="ParentcNum"
             className="w-full bg-[#3e907f] text-white px-3 py-2 font-[Montserrat] border border-[#254151] m-1 rounded-sm"
             readOnly={formState ?? true}
+            value={guardians[index].contact_number}
+            onChange={e => changeField('contact_number', e.target.value)}
             />
         </div>
         </>

--- a/src/routes/BeneficiaryCrud.test.tsx
+++ b/src/routes/BeneficiaryCrud.test.tsx
@@ -8,10 +8,11 @@ import { db } from '../firebase/firebaseConfig';
 import { auth } from '../firebase/firebaseConfig'
 import { ToastContainer } from 'react-toastify';
 
+// Mock Firebase
 jest.mock('firebase/firestore', () => ({
-  collection: jest.fn(() => ({})),
+  collection: jest.fn(() => ({})), // Return a mock object
   addDoc: jest.fn(),
-  doc: jest.fn(() => ({})),
+  doc: jest.fn(() => ({})), // Return a mock object
   getDoc: jest.fn(),
   updateDoc: jest.fn(),
   Timestamp: {
@@ -33,7 +34,7 @@ jest.mock('../firebase/firebaseConfig', () => ({
   auth: {
     signOut: jest.fn(),
     onAuthStateChanged: jest.fn(callback => {
-        callback({ uid: 'test-uid', email: 'test@example.com' });
+        callback({ uid: 'test-uid', email: 'test@example.com' }); // Simulate logged-in user
         return jest.fn();
     }),
   },
@@ -94,6 +95,29 @@ describe('Beneficiary Creation', () => {
     await waitFor(() => {
       expect(screen.getByText(/Please fill up all fields!/i)).toBeInTheDocument();
     });
+  });
+
+    test('shows error if a required field contains only whitespace', async () => {
+        renderBeneficiaryProfileCreation();
+
+        fireEvent.change(screen.getByLabelText(/First Name/i), { target: { value: '  ' } });
+        // Fill other fields...
+        fireEvent.change(screen.getByLabelText(/Last Name/i), { target: { value: 'Doe' } });
+        fireEvent.change(screen.getByLabelText(/Birth Date/i), { target: { value: '2010-01-01' } });
+        fireEvent.change(screen.getByLabelText(/Address/i), { target: { value: '123 Main St' } });
+        fireEvent.change(screen.getByLabelText(/Grade Level/i), { target: { value: '5' } });
+        const guardian1Card = screen.getByText(/Guardian 1/i).closest('div');
+        fireEvent.change(within(guardian1Card!).getByLabelText(/Name:/i), { target: { value: 'Jane Doe' } });
+        fireEvent.change(within(guardian1Card!).getByLabelText(/Relation:/i), { target: { value: 'Mother' } });
+        fireEvent.change(within(guardian1Card!).getByLabelText(/Email:/i), { target: { value: 'jane@example.com' } });
+        fireEvent.change(within(guardian1Card!).getByLabelText(/Contact Number:/i), { target: { value: '09123456789' } });
+
+
+        fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+        await waitFor(() => {
+        expect(screen.getByText(/Please fill up all fields!/i)).toBeInTheDocument();
+        });
   });
 
   test('successfully creates a beneficiary with one guardian', async () => {
@@ -169,7 +193,7 @@ describe('Beneficiary Creation', () => {
 
   test('shows error for invalid email format for guardian', async () => {
     renderBeneficiaryProfileCreation();
-  
+
     fireEvent.change(screen.getByLabelText(/ID no./i), { target: { value: '123' } });
     fireEvent.change(screen.getByLabelText(/Birth Date/i), { target: { value: '2010-01-01' } });
     fireEvent.change(screen.getByLabelText(/First Name/i), { target: { value: 'John' } });
@@ -177,17 +201,17 @@ describe('Beneficiary Creation', () => {
     fireEvent.change(screen.getByLabelText(/Sex/i), { target: { value: 'Male' } });
     fireEvent.change(screen.getByLabelText(/Grade Level/i), { target: { value: '5' } });
     fireEvent.change(screen.getByLabelText(/Address/i), { target: { value: '123 Main St' } });
-  
+
     const guardian1Card = screen.getByText(/Guardian 1/i).closest('div');
     expect(guardian1Card).not.toBeNull();
-  
+
     fireEvent.change(within(guardian1Card!).getByLabelText(/Name:/i), { target: { value: 'Jane Doe' } });
     fireEvent.change(within(guardian1Card!).getByLabelText(/Relation:/i), { target: { value: 'Mother' } });
     fireEvent.change(within(guardian1Card!).getByLabelText(/Email:/i), { target: { value: 'invalid-email' } });
     fireEvent.change(within(guardian1Card!).getByLabelText(/Contact Number:/i), { target: { value: '09123456789' } });
-  
+
     fireEvent.click(screen.getByRole('button', { name: /create account/i }));
-  
+
     await waitFor(() => {
       expect(screen.getByText(/Please input a proper email/i)).toBeInTheDocument();
     });
@@ -240,25 +264,25 @@ describe('Beneficiary Creation', () => {
 
   test('should allow removing guardians down to 1', async () => {
     renderBeneficiaryProfileCreation();
-  
+
     const addButton = screen.getByRole('button', { name: '+' });
     const subtractButton = screen.getByRole('button', { name: '-' });
-  
+
     fireEvent.click(addButton);
     fireEvent.click(addButton);
-  
+
     await screen.findByText(/Guardian 3/i);
-  
+
     fireEvent.click(subtractButton);
     await waitFor(() => {
       expect(screen.queryByText(/Guardian 3/i)).not.toBeInTheDocument();
     });
-  
+
     fireEvent.click(subtractButton);
     await waitFor(() => {
       expect(screen.queryByText(/Guardian 2/i)).not.toBeInTheDocument();
     });
-  
+
     fireEvent.click(subtractButton);
     await waitFor(() => {
       expect(screen.getByText(/Cannot have 0 guardians!/i)).toBeInTheDocument();
@@ -302,7 +326,7 @@ describe('Retrieve Beneficiary Profile', () => {
 
     test('displays beneficiary information after fetching', async () => {
         renderBeneficiaryProfile();
-      
+
         await waitFor(() => {
           expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument();
           expect(screen.getByDisplayValue('123')).toBeInTheDocument();
@@ -310,10 +334,10 @@ describe('Retrieve Beneficiary Profile', () => {
           expect(screen.getByDisplayValue('Female')).toBeInTheDocument();
           expect(screen.getByDisplayValue('3')).toBeInTheDocument();
           expect(screen.getByDisplayValue('456 Test Ave')).toBeInTheDocument();
-          
+
           const guardian1Card = screen.getByText(/Guardian 1/i).closest('div');
           expect(guardian1Card).not.toBeNull();
-      
+
           expect(within(guardian1Card!).getByDisplayValue('Parent One')).toBeInTheDocument();
           expect(within(guardian1Card!).getByDisplayValue('Father')).toBeInTheDocument();
           expect(within(guardian1Card!).getByDisplayValue('parent1@example.com')).toBeInTheDocument();
@@ -398,17 +422,17 @@ describe('Beneficiary Update', () => {
 
     test('allows adding and saving new guardian information', async () => {
         renderBeneficiaryProfile();
-    
+
         await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
-    
+
         fireEvent.click(screen.getByRole('button', { name: /edit/i }));
         fireEvent.click(screen.getByRole('button', { name: '+' }));
-    
+
         const guardian2Container = await screen.findByText(/Guardian 2/i);
         const guardian2Card = guardian2Container.closest('div');
         expect(guardian2Card).not.toBeNull();
-    
-        // use querySelector to avoid issues with duplicate IDs
+
+        // Use querySelector to avoid issues with duplicate IDs
         const nameInput = guardian2Card!.querySelector('input[name="ParentName"]');
         const relationInput = guardian2Card!.querySelector('input[name="Relation"]');
         const emailInput = guardian2Card!.querySelector('input[name="email"]');
@@ -423,9 +447,9 @@ describe('Beneficiary Update', () => {
         fireEvent.change(relationInput!, { target: { value: 'Aunt' } });
         fireEvent.change(emailInput!, { target: { value: 'new@example.com' } });
         fireEvent.change(contactInput!, { target: { value: '09987654321' } });
-    
+
         fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
-    
+
         await waitFor(() => {
           expect(updateDoc).toHaveBeenCalledWith(
             expect.anything(),
@@ -441,16 +465,16 @@ describe('Beneficiary Update', () => {
 
       test('shows error if guardian fields are incomplete during update', async () => {
         renderBeneficiaryProfile();
-    
+
         await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
-    
+
         fireEvent.click(screen.getByRole('button', { name: /edit/i }));
         fireEvent.click(screen.getByRole('button', { name: '+' }));
-    
+
         const guardian2Container = await screen.findByText(/Guardian 2/i);
         const guardian2Card = guardian2Container.closest('div');
         expect(guardian2Card).not.toBeNull();
-    
+
         const nameInput = guardian2Card!.querySelector('input[name="ParentName"]');
         const relationInput = guardian2Card!.querySelector('input[name="Relation"]');
         const contactInput = guardian2Card!.querySelector('input[name="ParentcNum"]');
@@ -458,54 +482,74 @@ describe('Beneficiary Update', () => {
         fireEvent.change(nameInput!, { target: { value: 'New Guardian' } });
         fireEvent.change(relationInput!, { target: { value: 'Aunt' } });
         fireEvent.change(contactInput!, { target: { value: '09987654321' } });
-    
+
         fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
-    
+
         await waitFor(() => {
           expect(screen.getByText(/Please fill up all fields for Guardian 2/i)).toBeInTheDocument();
         });
       });
-    
+
+      test('shows error for invalid guardian contact number during update', async () => {
+        renderBeneficiaryProfile();
+
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+        const guardianCard = screen.getByText(/Guardian 1/i).closest('div');
+        const contactInput = guardianCard!.querySelector('input[name="ParentcNum"]');
+
+        fireEvent.change(contactInput!, { target: { value: '12345' } }); // Invalid number
+
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => {
+          expect(screen.getByText(/Please input a proper contact number for Guardian 1/i)).toBeInTheDocument();
+        });
+      });
+
+
       test('allows discarding changes to beneficiary profile', async () => {
         renderBeneficiaryProfile();
-    
+
         await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
-    
+
         fireEvent.click(screen.getByRole('button', { name: /edit/i }));
-    
+
         const addressInput = screen.getByLabelText(/Address:/i);
         fireEvent.change(addressInput, { target: { value: 'Temp Address' } });
-    
+
         fireEvent.click(screen.getByRole('button', { name: /discard/i }));
-    
+
         await waitFor(() => {
           expect(addressInput).toHaveValue('456 Test Ave');
           expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
         });
       });
-    
+
       test('opens and closes delete confirmation modal', async () => {
         renderBeneficiaryProfile();
-    
+
         await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
-    
+
         fireEvent.click(screen.getByRole('button', { name: /delete account/i }));
         expect(screen.getByText(/Confirm Deletion/i)).toBeInTheDocument();
-    
+
         fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
         await waitFor(() => {
             expect(screen.queryByText(/Confirm Deletion/i)).not.toBeInTheDocument();
         })
       });
-    
+
       test('confirms account deletion and navigates to login', async () => {
         renderBeneficiaryProfile();
-    
+
         await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
-    
+
         fireEvent.click(screen.getByRole('button', { name: /delete account/i }));
         fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }));
-    
+
         await waitFor(() => {
           expect(updateDoc).toHaveBeenCalledWith(
             expect.anything(),
@@ -517,19 +561,37 @@ describe('Beneficiary Update', () => {
           expect(mockedNavigate).toHaveBeenCalledWith('/');
         });
       });
-    
-      test('shows error for invalid grade level during update', async () => {
+
+      test('shows error for invalid grade level (too high) during update', async () => {
         renderBeneficiaryProfile();
-    
+
         await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
-    
+
         fireEvent.click(screen.getByRole('button', { name: /edit/i }));
-    
+
         const gradeLevelInput = screen.getByLabelText(/Grade Level:/i);
         fireEvent.change(gradeLevelInput, { target: { value: '13' } });
-    
+
         fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
-    
+
+        await waitFor(() => {
+          expect(screen.getByText(/Please put a valid Grade Number/i)).toBeInTheDocument();
+          expect(updateDoc).not.toHaveBeenCalled();
+        });
+      });
+
+      test('shows error for invalid grade level (zero) during update', async () => {
+        renderBeneficiaryProfile();
+
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+        const gradeLevelInput = screen.getByLabelText(/Grade Level:/i);
+        fireEvent.change(gradeLevelInput, { target: { value: '0' } });
+
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
         await waitFor(() => {
           expect(screen.getByText(/Please put a valid Grade Number/i)).toBeInTheDocument();
           expect(updateDoc).not.toHaveBeenCalled();

--- a/src/routes/BeneficiaryCrud.test.tsx
+++ b/src/routes/BeneficiaryCrud.test.tsx
@@ -239,7 +239,7 @@ describe('Beneficiary Creation', () => {
     fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Please input a valid phone number/i)).toBeInTheDocument();
+      expect(screen.getByText(/Please input a proper contact number for Guardian 1/i)).toBeInTheDocument();
     });
   });
 

--- a/src/routes/BeneficiaryCrud.test.tsx
+++ b/src/routes/BeneficiaryCrud.test.tsx
@@ -1,0 +1,538 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { BeneficiaryProfileCreation } from './ProfileCreation';
+import { BeneficiaryProfile } from './BeneficiaryProfile';
+import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { addDoc, collection, doc, getDoc, updateDoc, Timestamp } from 'firebase/firestore';
+import { db } from '../firebase/firebaseConfig';
+import { auth } from '../firebase/firebaseConfig'
+import { ToastContainer } from 'react-toastify';
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(() => ({})),
+  addDoc: jest.fn(),
+  doc: jest.fn(() => ({})),
+  getDoc: jest.fn(),
+  updateDoc: jest.fn(),
+  Timestamp: {
+    fromMillis: jest.fn((ms) => ({
+      seconds: Math.floor(ms / 1000),
+      nanoseconds: (ms % 1000) * 1_000_000,
+      toDate: () => new Date(ms),
+    })),
+    fromDate: jest.fn((date: Date) => ({
+      seconds: Math.floor(date.getTime() / 1000),
+      nanoseconds: (date.getTime() % 1000) * 1_000_000,
+      toDate: () => date,
+    })),
+  },
+}));
+
+jest.mock('../firebase/firebaseConfig', () => ({
+  db: {},
+  auth: {
+    signOut: jest.fn(),
+    onAuthStateChanged: jest.fn(callback => {
+        callback({ uid: 'test-uid', email: 'test@example.com' });
+        return jest.fn();
+    }),
+  },
+}));
+
+const mockedNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedNavigate,
+  useParams: () => ({ docId: 'test-beneficiary-id' }),
+}));
+
+function renderBeneficiaryProfileCreation() {
+  return render(
+    <BrowserRouter>
+      <BeneficiaryProfileCreation />
+      <ToastContainer />
+    </BrowserRouter>
+  );
+}
+
+function renderBeneficiaryProfile(initialDocId = 'test-beneficiary-id') {
+    return render(
+      <MemoryRouter initialEntries={[`/beneficiary-profile/${initialDocId}`]}>
+        <Routes>
+          <Route path="/beneficiary-profile/:docId" element={<BeneficiaryProfile />} />
+          <Route path="/" element={<div>Login Page</div>} />
+        </Routes>
+        <ToastContainer />
+      </MemoryRouter>
+    );
+  }
+
+describe('Beneficiary Creation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders beneficiary creation form fields', () => {
+    renderBeneficiaryProfileCreation();
+
+    expect(screen.getByLabelText(/ID no./i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Birth Date/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/First Name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Last Name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Sex/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Grade Level/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Address/i)).toBeInTheDocument();
+    expect(screen.getByText(/Guardian Information/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
+  });
+
+  test('shows error if all fields are not filled during creation', async () => {
+    renderBeneficiaryProfileCreation();
+
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Please fill up all fields!/i)).toBeInTheDocument();
+    });
+  });
+
+  test('successfully creates a beneficiary with one guardian', async () => {
+    (addDoc as jest.Mock).mockResolvedValue({ id: 'new-beneficiary-id' });
+
+    renderBeneficiaryProfileCreation();
+
+    fireEvent.change(screen.getByLabelText(/ID no./i), { target: { value: '123' } });
+    fireEvent.change(screen.getByLabelText(/Birth Date/i), { target: { value: '2010-01-01' } });
+    fireEvent.change(screen.getByLabelText(/First Name/i), { target: { value: 'John' } });
+    fireEvent.change(screen.getByLabelText(/Last Name/i), { target: { value: 'Doe' } });
+    fireEvent.change(screen.getByLabelText(/Sex/i), { target: { value: 'Male' } });
+    fireEvent.change(screen.getByLabelText(/Grade Level/i), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText(/Address/i), { target: { value: '123 Main St' } });
+
+    const guardian1Card = screen.getByText(/Guardian 1/i).closest('div');
+    expect(guardian1Card).not.toBeNull();
+
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Name:/i), { target: { value: 'Jane Doe' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Relation:/i), { target: { value: 'Mother' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Email:/i), { target: { value: 'jane@example.com' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Contact Number:/i), { target: { value: '09123456789' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+        expect(addDoc).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            accredited_id: 123,
+            first_name: 'John',
+            last_name: 'Doe',
+          })
+        );
+      expect(screen.getByText(/Success!/i)).toBeInTheDocument();
+    });
+  });
+
+  test('successfully creates a waitlisted beneficiary (no ID)', async () => {
+    (addDoc as jest.Mock).mockResolvedValue({ id: 'new-beneficiary-id' });
+
+    renderBeneficiaryProfileCreation();
+
+    // No ID entered
+    fireEvent.change(screen.getByLabelText(/Birth Date/i), { target: { value: '2010-01-01' } });
+    fireEvent.change(screen.getByLabelText(/First Name/i), { target: { value: 'John' } });
+    fireEvent.change(screen.getByLabelText(/Last Name/i), { target: { value: 'Doe' } });
+    fireEvent.change(screen.getByLabelText(/Sex/i), { target: { value: 'Male' } });
+    fireEvent.change(screen.getByLabelText(/Grade Level/i), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText(/Address/i), { target: { value: '123 Main St' } });
+
+    const guardian1Card = screen.getByText(/Guardian 1/i).closest('div');
+    expect(guardian1Card).not.toBeNull();
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Name:/i), { target: { value: 'Jane Doe' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Relation:/i), { target: { value: 'Mother' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Email:/i), { target: { value: 'jane@example.com' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Contact Number:/i), { target: { value: '09123456789' } });
+
+
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(addDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          accredited_id: NaN,
+          is_waitlisted: true,
+        })
+      );
+      expect(screen.getByText(/Success!/i)).toBeInTheDocument();
+    });
+  });
+
+  test('shows error for invalid email format for guardian', async () => {
+    renderBeneficiaryProfileCreation();
+  
+    fireEvent.change(screen.getByLabelText(/ID no./i), { target: { value: '123' } });
+    fireEvent.change(screen.getByLabelText(/Birth Date/i), { target: { value: '2010-01-01' } });
+    fireEvent.change(screen.getByLabelText(/First Name/i), { target: { value: 'John' } });
+    fireEvent.change(screen.getByLabelText(/Last Name/i), { target: { value: 'Doe' } });
+    fireEvent.change(screen.getByLabelText(/Sex/i), { target: { value: 'Male' } });
+    fireEvent.change(screen.getByLabelText(/Grade Level/i), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText(/Address/i), { target: { value: '123 Main St' } });
+  
+    const guardian1Card = screen.getByText(/Guardian 1/i).closest('div');
+    expect(guardian1Card).not.toBeNull();
+  
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Name:/i), { target: { value: 'Jane Doe' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Relation:/i), { target: { value: 'Mother' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Email:/i), { target: { value: 'invalid-email' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Contact Number:/i), { target: { value: '09123456789' } });
+  
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+  
+    await waitFor(() => {
+      expect(screen.getByText(/Please input a proper email/i)).toBeInTheDocument();
+    });
+  });
+
+  test('shows error for invalid contact number format for guardian', async () => {
+    renderBeneficiaryProfileCreation();
+
+    fireEvent.change(screen.getByLabelText(/ID no./i), { target: { value: '123' } });
+    fireEvent.change(screen.getByLabelText(/Birth Date/i), { target: { value: '2010-01-01' } });
+    fireEvent.change(screen.getByLabelText(/First Name/i), { target: { value: 'John' } });
+    fireEvent.change(screen.getByLabelText(/Last Name/i), { target: { value: 'Doe' } });
+    fireEvent.change(screen.getByLabelText(/Sex/i), { target: { value: 'Male' } });
+    fireEvent.change(screen.getByLabelText(/Grade Level/i), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText(/Address/i), { target: { value: '123 Main St' } });
+
+    const guardian1Card = screen.getByText(/Guardian 1/i).closest('div');
+    expect(guardian1Card).not.toBeNull();
+
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Name:/i), { target: { value: 'Jane Doe' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Relation:/i), { target: { value: 'Mother' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Email:/i), { target: { value: 'jane@example.com' } });
+    fireEvent.change(within(guardian1Card!).getByLabelText(/Contact Number:/i), { target: { value: '123' } }); // Too short
+
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Please input a valid phone number/i)).toBeInTheDocument();
+    });
+  });
+
+  test('should allow adding up to 3 guardians', async () => {
+    renderBeneficiaryProfileCreation();
+
+    const addButton = screen.getByRole('button', { name: '+' });
+
+    fireEvent.click(addButton);
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Guardian 2/i)).toBeInTheDocument();
+      expect(screen.getByText(/Guardian 3/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(addButton);
+    await waitFor(() => {
+      expect(screen.getByText(/Cannot add more than 3 guardians!/i)).toBeInTheDocument();
+    });
+  });
+
+  test('should allow removing guardians down to 1', async () => {
+    renderBeneficiaryProfileCreation();
+  
+    const addButton = screen.getByRole('button', { name: '+' });
+    const subtractButton = screen.getByRole('button', { name: '-' });
+  
+    fireEvent.click(addButton);
+    fireEvent.click(addButton);
+  
+    await screen.findByText(/Guardian 3/i);
+  
+    fireEvent.click(subtractButton);
+    await waitFor(() => {
+      expect(screen.queryByText(/Guardian 3/i)).not.toBeInTheDocument();
+    });
+  
+    fireEvent.click(subtractButton);
+    await waitFor(() => {
+      expect(screen.queryByText(/Guardian 2/i)).not.toBeInTheDocument();
+    });
+  
+    fireEvent.click(subtractButton);
+    await waitFor(() => {
+      expect(screen.getByText(/Cannot have 0 guardians!/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Retrieve Beneficiary Profile', () => {
+    const mockBeneficiaryData = {
+        accredited_id: 123,
+        first_name: 'Test',
+        last_name: 'Beneficiary',
+        address: '456 Test Ave',
+        birthdate: Timestamp.fromDate(new Date('2015-05-10')),
+        grade_level: 3,
+        sex: 'Female',
+        guardians: [
+            { name: 'Parent One', relation: 'Father', email: 'parent1@example.com', contact_number: '09123456789' },
+        ],
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getDoc as jest.Mock).mockResolvedValue({
+            exists: () => true,
+            data: () => mockBeneficiaryData,
+            id: 'test-beneficiary-id',
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+
+    test('displays "Fetching..." while data is loading', async () => {
+        (getDoc as jest.Mock).mockReturnValue(new Promise(() => {}));
+        renderBeneficiaryProfile();
+        expect(screen.getByText(/Fetching.../i)).toBeInTheDocument();
+    });
+
+    test('displays beneficiary information after fetching', async () => {
+        renderBeneficiaryProfile();
+      
+        await waitFor(() => {
+          expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument();
+          expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+          expect(screen.getByDisplayValue('2015-05-10')).toBeInTheDocument();
+          expect(screen.getByDisplayValue('Female')).toBeInTheDocument();
+          expect(screen.getByDisplayValue('3')).toBeInTheDocument();
+          expect(screen.getByDisplayValue('456 Test Ave')).toBeInTheDocument();
+          
+          const guardian1Card = screen.getByText(/Guardian 1/i).closest('div');
+          expect(guardian1Card).not.toBeNull();
+      
+          expect(within(guardian1Card!).getByDisplayValue('Parent One')).toBeInTheDocument();
+          expect(within(guardian1Card!).getByDisplayValue('Father')).toBeInTheDocument();
+          expect(within(guardian1Card!).getByDisplayValue('parent1@example.com')).toBeInTheDocument();
+          expect(within(guardian1Card!).getByDisplayValue('09123456789')).toBeInTheDocument();
+        });
+      });
+
+    test('redirects to login if no user is logged in', async () => {
+        (auth.onAuthStateChanged as jest.Mock).mockImplementation(callback => {
+            callback(null);
+            return jest.fn();
+        });
+        renderBeneficiaryProfile();
+        await waitFor(() => {
+            expect(mockedNavigate).toHaveBeenCalledWith('/');
+        });
+    });
+});
+
+describe('Beneficiary Update', () => {
+    const mockBeneficiaryData = {
+        accredited_id: 123,
+        first_name: 'Test',
+        last_name: 'Beneficiary',
+        address: '456 Test Ave',
+        birthdate: Timestamp.fromDate(new Date('2015-05-10')),
+        grade_level: 3,
+        sex: 'Female',
+        guardians: [
+            { name: 'Parent One', relation: 'Father', email: 'parent1@example.com', contact_number: '09123456789' },
+        ],
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getDoc as jest.Mock).mockResolvedValue({
+            exists: () => true,
+            data: () => mockBeneficiaryData,
+            id: 'test-beneficiary-id',
+        });
+        (updateDoc as jest.Mock).mockResolvedValue(undefined);
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { reload: jest.fn() },
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('allows editing and saving changes to beneficiary profile', async () => {
+        renderBeneficiaryProfile();
+
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+        const addressInput = screen.getByLabelText(/Address:/i);
+        fireEvent.change(addressInput, { target: { value: '789 New St' } });
+
+        const gradeLevelInput = screen.getByLabelText(/Grade Level:/i);
+        fireEvent.change(gradeLevelInput, { target: { value: '4' } });
+
+        const sexInput = screen.getByLabelText(/Sex:/i);
+        fireEvent.change(sexInput, { target: { value: 'Male' } });
+
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => {
+            expect(updateDoc).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    address: '789 New St',
+                    grade_level: 4,
+                    sex: 'Male'
+                })
+            );
+            expect(screen.getByText(/Account update success!/i)).toBeInTheDocument();
+        });
+    });
+
+    test('allows adding and saving new guardian information', async () => {
+        renderBeneficiaryProfile();
+    
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+    
+        fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+        fireEvent.click(screen.getByRole('button', { name: '+' }));
+    
+        const guardian2Container = await screen.findByText(/Guardian 2/i);
+        const guardian2Card = guardian2Container.closest('div');
+        expect(guardian2Card).not.toBeNull();
+    
+        // use querySelector to avoid issues with duplicate IDs
+        const nameInput = guardian2Card!.querySelector('input[name="ParentName"]');
+        const relationInput = guardian2Card!.querySelector('input[name="Relation"]');
+        const emailInput = guardian2Card!.querySelector('input[name="email"]');
+        const contactInput = guardian2Card!.querySelector('input[name="ParentcNum"]');
+
+        expect(nameInput).toBeInTheDocument();
+        expect(relationInput).toBeInTheDocument();
+        expect(emailInput).toBeInTheDocument();
+        expect(contactInput).toBeInTheDocument();
+
+        fireEvent.change(nameInput!, { target: { value: 'New Guardian' } });
+        fireEvent.change(relationInput!, { target: { value: 'Aunt' } });
+        fireEvent.change(emailInput!, { target: { value: 'new@example.com' } });
+        fireEvent.change(contactInput!, { target: { value: '09987654321' } });
+    
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+    
+        await waitFor(() => {
+          expect(updateDoc).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+              guardians: expect.arrayContaining([
+                expect.objectContaining({ name: 'Parent One' }),
+                expect.objectContaining({ name: 'New Guardian' }),
+              ]),
+            })
+          );
+        });
+      });
+
+      test('shows error if guardian fields are incomplete during update', async () => {
+        renderBeneficiaryProfile();
+    
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+    
+        fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+        fireEvent.click(screen.getByRole('button', { name: '+' }));
+    
+        const guardian2Container = await screen.findByText(/Guardian 2/i);
+        const guardian2Card = guardian2Container.closest('div');
+        expect(guardian2Card).not.toBeNull();
+    
+        const nameInput = guardian2Card!.querySelector('input[name="ParentName"]');
+        const relationInput = guardian2Card!.querySelector('input[name="Relation"]');
+        const contactInput = guardian2Card!.querySelector('input[name="ParentcNum"]');
+
+        fireEvent.change(nameInput!, { target: { value: 'New Guardian' } });
+        fireEvent.change(relationInput!, { target: { value: 'Aunt' } });
+        fireEvent.change(contactInput!, { target: { value: '09987654321' } });
+    
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+    
+        await waitFor(() => {
+          expect(screen.getByText(/Please fill up all fields for Guardian 2/i)).toBeInTheDocument();
+        });
+      });
+    
+      test('allows discarding changes to beneficiary profile', async () => {
+        renderBeneficiaryProfile();
+    
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+    
+        fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    
+        const addressInput = screen.getByLabelText(/Address:/i);
+        fireEvent.change(addressInput, { target: { value: 'Temp Address' } });
+    
+        fireEvent.click(screen.getByRole('button', { name: /discard/i }));
+    
+        await waitFor(() => {
+          expect(addressInput).toHaveValue('456 Test Ave');
+          expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+        });
+      });
+    
+      test('opens and closes delete confirmation modal', async () => {
+        renderBeneficiaryProfile();
+    
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+    
+        fireEvent.click(screen.getByRole('button', { name: /delete account/i }));
+        expect(screen.getByText(/Confirm Deletion/i)).toBeInTheDocument();
+    
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+        await waitFor(() => {
+            expect(screen.queryByText(/Confirm Deletion/i)).not.toBeInTheDocument();
+        })
+      });
+    
+      test('confirms account deletion and navigates to login', async () => {
+        renderBeneficiaryProfile();
+    
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+    
+        fireEvent.click(screen.getByRole('button', { name: /delete account/i }));
+        fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }));
+    
+        await waitFor(() => {
+          expect(updateDoc).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+              time_to_live: expect.any(Number),
+            })
+          );
+          expect(screen.getByText(/Account delete success!/i)).toBeInTheDocument();
+          expect(mockedNavigate).toHaveBeenCalledWith('/');
+        });
+      });
+    
+      test('shows error for invalid grade level during update', async () => {
+        renderBeneficiaryProfile();
+    
+        await waitFor(() => expect(screen.getByText('Beneficiary, Test')).toBeInTheDocument());
+    
+        fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    
+        const gradeLevelInput = screen.getByLabelText(/Grade Level:/i);
+        fireEvent.change(gradeLevelInput, { target: { value: '13' } });
+    
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+    
+        await waitFor(() => {
+          expect(screen.getByText(/Please put a valid Grade Number/i)).toBeInTheDocument();
+          expect(updateDoc).not.toHaveBeenCalled();
+        });
+      });
+});

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -273,7 +273,7 @@ export function BeneficiaryProfile() {
                           (_, i) => (
                             <div className="pb-4">
                               <h3 className="font-[Montserrat] mb-2">Guardian {i + 1}</h3>
-                              <GuardianCard formState={false} />
+                              {/*<GuardianCard formState={false} /> TODO: Change this (use beneficiary profile creation as reference*/}
                             </div>
                           )
                         )}

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -122,12 +122,14 @@ export function BeneficiaryProfile() {
 
     const handleSave = 
     async () => {
-        if(!sex || !level || !address || !birthdate)
+        if(!sex || !level || !address || !birthdate){
+            toast.error("Please fill up all fields!")
             return
-        if(sex != "M" && sex != "F")
-            return
-        if(level > 12 || level < 1)
+        }
+        if(level > 12 || level < 1){
+            toast.error("Please put a valid Grade Number")
             return 
+        }
         const updateRef = doc(db, "beneficiaries", docID!)
         console.log(beneficiary)
         

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -97,9 +97,8 @@ export function BeneficiaryProfile() {
     
     function handleSub(){
         if (guardians.length-1 >= 1){
-            /* same here */
-            const reducedGuardians = guardians
-            reducedGuardians.pop()
+            // applied
+            const reducedGuardians = guardians.slice(0, -1);
             setGuardians(reducedGuardians)
             setBeneficiary({ ...beneficiary as Beneficiary, guardians: reducedGuardians })
         }

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -231,7 +231,7 @@ export function BeneficiaryProfile() {
             )}
             <div className="relative w-full max-w-4xl rounded-md flex flex-col items-center pt-8 pb-10 px-4 sm:px-6 overflow-hidden">
             <div className="-top-5 sm:-top-20 z-10 w-32 h-32 sm:w-36 sm:h-36 bg-gray-500 border-[5px] border-[#45B29D] rounded-full flex items-center justify-center mb-1">
-                <i className="text-[6rem] sm:text-[8rem] text-gray-300 fi fi-ss-circle-user"></i>
+                <i className="flex text-[6rem] sm:text-[8rem] text-gray-300 fi fi-ss-circle-user"></i>
             </div>
 
             <button

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -133,7 +133,7 @@ export function BeneficiaryProfile() {
         // convert string input to number, if valid
         const gradeLevelNum = Number(gradeLevel);
 
-        if(!sex || !gradeLevel || !address || !birthdate){
+        if(!(sex!.toString().trim()) || !gradeLevel || gradeLevelNum != 0 || !(address!.toString().trim()) || !birthdate){
             toast.error("Please fill up all fields!")
             return
         }
@@ -150,7 +150,7 @@ export function BeneficiaryProfile() {
         let test = false
         guardians.forEach((guardian, i) => {
             Object.values(guardian).forEach((val, _) => {
-                if(!val) {
+                if(!(val.toString().trim())) {
                     toast.error("Please fill up all fields for Guardian " + (i+1));
                     test = true
                     return

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -12,7 +12,7 @@ import { createPortal } from 'react-dom';
 import type { Guardian } from "../models/guardianType.ts";
 
 export function BeneficiaryProfile() {
-    // const params = useParams()
+    const params = useParams()
     const [beneficiary, setBeneficiary] = useState<Beneficiary | null>(null)
     const [originalBenificiary, setOriginalBeneficiary] = useState<Beneficiary | null>(null)
     //formState = null, all disabled
@@ -30,7 +30,7 @@ export function BeneficiaryProfile() {
 
     useEffect(() =>  {
         const fetchBeneficiary = async () => {
-        const getQuery = doc(db, "beneficiaries", "SRlWXRPnbM73GFXqa6wl") // note: hardcoded beneficiary
+        const getQuery = doc(db, "beneficiaries", params.docId as string)
         const beneficiariesSnap = await getDoc(getQuery)
         if(beneficiariesSnap.exists())
             setBeneficiary(beneficiariesSnap.data() as Beneficiary)
@@ -66,6 +66,11 @@ export function BeneficiaryProfile() {
     function handleEdit(){
         if (formState === false && originalBenificiary) {
             setBeneficiary(originalBenificiary);
+            
+            // if guardians were modified, return to original
+            if (guardians.length != originalBenificiary.guardians.length) {
+                setGuardians(originalBenificiary.guardians);
+            }
         }
         setForm(!formState)
     }
@@ -265,7 +270,7 @@ export function BeneficiaryProfile() {
                         id="bDate"
                         className="w-full text-white border border-[#254151] bg-[#3EA08D] rounded px-3 py-2 font-[Montserrat]"
                         readOnly={formState ?? true}
-                        onChange={(e) => setBeneficiary({...beneficiary as Beneficiary, birthdate : Timestamp.fromDate(birthdate)})}
+                        onChange={(e) => setBeneficiary({...beneficiary as Beneficiary, birthdate : Timestamp.fromDate((new Date (e.target.value)))})}
                         value={birthdate?.toISOString().substring(0,10)}/>
                     </div>
 

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -133,10 +133,16 @@ export function BeneficiaryProfile() {
         // convert string input to number, if valid
         const gradeLevelNum = Number(gradeLevel);
 
-        if(!(sex!.toString().trim()) || !gradeLevel || gradeLevelNum != 0 || !(address!.toString().trim()) || !birthdate){
+        /* changed */
+        // gradeLevelNum != 0 will only be true if gradeLevelNum is 0
+        // modified others rin, it still checks for empty strings/whitespaces
+        /*if(!(sex!.toString().trim()) || !gradeLevel || gradeLevelNum != 0 || !(address!.toString().trim()) || !birthdate){*/
+        if (!sex?.trim() || !gradeLevel.trim() || !address?.trim() || !birthdate) {
             toast.error("Please fill up all fields!")
             return
-        }
+        }       
+        /* end of change */
+
         if(gradeLevelNum > 12 || gradeLevelNum < 1 || isNaN(gradeLevelNum)){
             toast.error("Please put a valid Grade Number")
             return 

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -90,6 +90,19 @@ export function BeneficiaryProfile() {
         setDeleteModal(!showDeleteModal)
     }
 
+    const handleConfirm = async () => {
+        setDeleteModal(!showDeleteModal)
+        
+        const updateRef = doc(db, "beneficiaries", docID!)
+        console.log(beneficiary)
+        await updateDoc(updateRef, {
+        ...beneficiary,
+        time_to_live : (Date.now() + 2592000000)
+        })
+        toast.success("Account delete success!")
+        navigate("/")
+    }
+
     const handleSave = 
     async () => {
         if(!sex || !level)
@@ -136,7 +149,7 @@ export function BeneficiaryProfile() {
                             </button>
                             <button
                                 className="bg-red-600 hover:bg-red-700 text-white font-semibold px-4 py-2 rounded"
-                                onClick={handleDelete} // TODO: REPLACE
+                                onClick={handleConfirm}
                             >
                                 Confirm Delete
                             </button>

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -1,15 +1,15 @@
-import EventCard from "../components/EventCard.tsx";
+import EventCard from "../components/EventCard";
 import { useNavigate, useParams } from "react-router";
 import "../css/styles.css";
-import { UserContext } from "../context/userContext.ts";
+import { UserContext } from "../context/userContext";
 import { useContext, useEffect, useState } from "react";
 import { auth, db } from "../firebase/firebaseConfig";
 import { doc, getDoc, Timestamp, updateDoc } from "firebase/firestore"
-import type { Beneficiary } from "../models/beneficiaryType.ts";
-import GuardianCard from "../components/GuardianCard.tsx";
+import type { Beneficiary } from "../models/beneficiaryType";
+import GuardianCard from "../components/GuardianCard";
 import { toast } from "react-toastify";
 import { createPortal } from 'react-dom';
-import type { Guardian } from "../models/guardianType.ts";
+import type { Guardian } from "../models/guardianType";
 
 export function BeneficiaryProfile() {
     const params = useParams()
@@ -97,6 +97,7 @@ export function BeneficiaryProfile() {
     
     function handleSub(){
         if (guardians.length-1 >= 1){
+            /* same here */
             const reducedGuardians = guardians
             reducedGuardians.pop()
             setGuardians(reducedGuardians)

--- a/src/routes/BeneficiaryProfile.tsx
+++ b/src/routes/BeneficiaryProfile.tsx
@@ -27,6 +27,8 @@ export function BeneficiaryProfile() {
     const [minimizeState, setMinimize] = useState(false)
     const [showDeleteModal, setDeleteModal] = useState(false)
     const [docID, setDocID] = useState(beneficiary?.docID)
+    const [gradeLevel, setGradeLevel] = useState<string>("");
+
 
     useEffect(() =>  {
         const fetchBeneficiary = async () => {
@@ -38,6 +40,7 @@ export function BeneficiaryProfile() {
             setGuardians((beneficiariesSnap.data() as Beneficiary).guardians)
             console.log((beneficiariesSnap.data() as Beneficiary))
             setDocID(beneficiariesSnap.id)
+            setGradeLevel((beneficiariesSnap.data() as Beneficiary).grade_level.toString()) // see commit desc re: this change
             setForm(true)
         }
         fetchBeneficiary()
@@ -66,7 +69,7 @@ export function BeneficiaryProfile() {
     function handleEdit(){
         if (formState === false && originalBenificiary) {
             setBeneficiary(originalBenificiary);
-            
+            setGradeLevel(originalBenificiary.grade_level.toString());
             // if guardians were modified, return to original
             if (guardians.length != originalBenificiary.guardians.length) {
                 setGuardians(originalBenificiary.guardians);
@@ -127,11 +130,14 @@ export function BeneficiaryProfile() {
 
     const handleSave = 
     async () => {
-        if(!sex || !level || !address || !birthdate){
+        // convert string input to number, if valid
+        const gradeLevelNum = Number(gradeLevel);
+
+        if(!sex || !gradeLevel || !address || !birthdate){
             toast.error("Please fill up all fields!")
             return
         }
-        if(level > 12 || level < 1){
+        if(gradeLevelNum > 12 || gradeLevelNum < 1 || isNaN(gradeLevelNum)){
             toast.error("Please put a valid Grade Number")
             return 
         }
@@ -170,9 +176,10 @@ export function BeneficiaryProfile() {
         try {
             await updateDoc(updateRef, {
                 ...beneficiary,
-                guardians: guardians
+                guardians: guardians,
+                grade_level: gradeLevelNum
             })
-            setOriginalBeneficiary({...beneficiary as Beneficiary, guardians: guardians})
+            setOriginalBeneficiary({...beneficiary as Beneficiary, grade_level: gradeLevelNum,guardians: guardians})
             toast.success("Account update success!")
             setTimeout(function() {
                 location.reload();
@@ -300,8 +307,9 @@ export function BeneficiaryProfile() {
                     id="gLevel"
                     className="w-full text-white border border-[#254151] bg-[#3EA08D] rounded px-3 py-2 font-[Montserrat]"
                     readOnly={formState ?? true}
-                    onChange={(e) => setBeneficiary({...beneficiary as Beneficiary, grade_level : Number(e.target.value)})}
-                    value={level}/>
+                    onChange={(e) => setGradeLevel(e.target.value)}
+                    value={gradeLevel}
+                />
                 </div>
                 <div className="flex flex-col">
                     <label

--- a/src/routes/ProfileCreation.tsx
+++ b/src/routes/ProfileCreation.tsx
@@ -252,7 +252,6 @@ export function BeneficiaryProfileCreation() {
         key == "idNum" ? is_waitlisted = true : err = true
     }
 
-    const emailRegEx = new RegExp(/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/g);
     if (!err) {
       const emailRegEx = new RegExp(
         /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/

--- a/src/routes/ProfileCreation.tsx
+++ b/src/routes/ProfileCreation.tsx
@@ -6,7 +6,7 @@ Timestamp} from "firebase/firestore"
 import React from "react";
 import { useState } from "react";
 import type { Guardian } from "../models/guardianType";
-import GuardianCard from "../components/GuardianCard.tsx";
+import GuardianCard from "../components/GuardianCard";
 
 //password generator
 function GenPass(){
@@ -267,6 +267,16 @@ export function BeneficiaryProfileCreation() {
 
   function handleSub(){
     if (guardians.length-1 >= 1){
+      /* 
+      Error: 
+      remember that arrays are references? so we need to create a new copy instead
+      when reducedGuardians.pop() is called, it modifies the original one
+      for some reason according to Gemini, React doesn't see the update if ^^, so it doesn't re-render the component
+
+      Possible Solution:
+      const reducedGuardians = guardians.slice(0, -1);
+      setGuardians(reducedGuardians);
+      */
       const reducedGuardians = guardians
       reducedGuardians.pop()
       setGuardians(reducedGuardians)

--- a/src/routes/ProfileCreation.tsx
+++ b/src/routes/ProfileCreation.tsx
@@ -51,7 +51,7 @@ export function VolunteerProfileCreation() {
         return
       } else {
         const role = formData.get("dropdown") as string
-        const is_admin = (role == "Admin" ? true : false )
+        const is_admin = (role == "Admin")
         const addRef = await addDoc(collection(db, "volunteers"), {
           contact_number: formData.get("cNum") as string,
           email: formData.get("email") as string,
@@ -190,10 +190,6 @@ export function VolunteerProfileCreation() {
 
 export function BeneficiaryProfileCreation() {
   const navigate = useNavigate();
-  //formState = 0, 0 guardian (just because lol)
-  //formState = 1, 1 guardian
-  //formState = 2, 2 guardian
-  //formState = 3, 3 guardian
   const [guardians, setGuardians] = useState<Guardian[]>([{
     name: '',
     relation: '',
@@ -276,9 +272,10 @@ export function BeneficiaryProfileCreation() {
       Possible Solution:
       const reducedGuardians = guardians.slice(0, -1);
       setGuardians(reducedGuardians);
+
+      // noted, applied solution
       */
-      const reducedGuardians = guardians
-      reducedGuardians.pop()
+      const reducedGuardians = guardians.slice(0, -1);
       setGuardians(reducedGuardians)
     }
     else

--- a/src/routes/ProfileCreation.tsx
+++ b/src/routes/ProfileCreation.tsx
@@ -36,7 +36,9 @@ export function VolunteerProfileCreation() {
 
     const password = GenPass()
 
-    const emailRegEx = new RegExp(/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/g);
+    const emailRegEx = new RegExp(
+      /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
+    ); // from https://emailregex.com/
     if (!err) {
       if (!emailRegEx.test(formData.get("email") as string)) {
         toast.error("Please input a proper email.");
@@ -56,7 +58,7 @@ export function VolunteerProfileCreation() {
           first_name: formData.get("fName") as string,
           last_name: formData.get("lName") as string,
           is_admin: is_admin,
-          birthdate: Timestamp.fromMillis(Date.parse(/*formData.get("") as string*/ "2000-01-01T00:00:00.001Z")),
+          birthdate: Timestamp.fromMillis(Date.parse(formData.get("birthdate") as string)),
           address: formData.get("address") as string,
           sex: formData.get("SexDropdown") as string,
           role: role,

--- a/src/routes/ProfileCreation.tsx
+++ b/src/routes/ProfileCreation.tsx
@@ -192,7 +192,6 @@ export function BeneficiaryProfileCreation() {
   //formState = 1, 1 guardian
   //formState = 2, 2 guardian
   //formState = 3, 3 guardian
-  const [guardianState, setGuardianState] = useState(1)
   const [guardians, setGuardians] = useState<Guardian[]>([{
     name: '',
     relation: '',
@@ -252,8 +251,7 @@ export function BeneficiaryProfileCreation() {
   };
 
   function handleAdd(){
-    if (guardianState+1 <= 3){
-      setGuardianState(guardianState+1)
+    if (guardians.length+1 <= 3){
       setGuardians([...guardians, {
         name: '',
         relation: '',
@@ -266,8 +264,7 @@ export function BeneficiaryProfileCreation() {
   }
 
   function handleSub(){
-    if (guardianState-1 >= 1){
-      setGuardianState(guardianState-1)
+    if (guardians.length-1 >= 1){
       const reducedGuardians = guardians
       reducedGuardians.pop()
       setGuardians(reducedGuardians)
@@ -392,7 +389,7 @@ export function BeneficiaryProfileCreation() {
                     <div className={`overflow-auto transition-all duration-300 ease-in-out ${minimizeState ? "max-h-0 opacity-0" : "max-h-96 opacity-100"}`}>
                       <div className="w-full rounded-b-sm text-white border border-[#254151] bg-[#3EA08D] p-3">
                         {Array.from(
-                          {length: guardianState},
+                          {length: guardians.length},
                           (_, i) => (
                             <div className="pb-4">
                               <h3 className="font-[Montserrat] mb-2">Guardian {i + 1}</h3>

--- a/src/routes/ProfileCreation.tsx
+++ b/src/routes/ProfileCreation.tsx
@@ -31,7 +31,7 @@ export function VolunteerProfileCreation() {
     let err = false;
     for (const [, value] of formData.entries()) {
       console.log(value.toString(), err);
-      if (!value) err = true;
+      if (!(value.toString().trim())) err = true;
     }
 
     const password = GenPass()
@@ -211,25 +211,44 @@ export function BeneficiaryProfileCreation() {
     let is_waitlisted = false;
     for (const [key, value] of formData.entries()) {
       console.log(value.toString(), err);
-      if (!value)
+      if (!(value.toString().trim()))
         key == "idNum" ? is_waitlisted = true : err = true
     }
 
     const emailRegEx = new RegExp(/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/g);
     if (!err) {
-      if (!emailRegEx.test(formData.get("email") as string)) {
-        toast.error("Please input a proper email.");
-      } else if (
-        (formData.get("ParentcNum") as string).length != 11 ||
-        formData.get("ParentcNum")?.slice(0, 2) != "09"
-      ) {
-        toast.error(
-          "Please input a valid phone number." +
-            formData.get("cNum")?.toString.length
-        );
-      } else {
+      const emailRegEx = new RegExp(
+        /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
+      ); // from https://emailregex.com/
+      let test = false
+      guardians.forEach((guardian, i) => {
+          Object.values(guardian).forEach((val, _) => {
+              if(!(val.toString().trim())) {
+                  toast.error("Please fill up all fields for Guardian " + (i+1));
+                  test = true
+                  return
+              }
+          })
+          if(test)
+              return
+          else if (!emailRegEx.test(guardian.email)) {
+              console.log(guardian.email)
+              toast.error("Please input a proper email for Guardian " + (i+1));
+              test = true
+              return
+          }
+          else if (guardian.contact_number.length != 11 || guardian.contact_number.slice(0, 2) != "09") {
+              toast.error("Please input a proper contact number for Guardian " + (i+1));
+              test = true
+              return
+          }
+        });
+        if(test)
+            return 
+        else {
+        const accredited_id = Number((formData.get("idNum") as string).trim())
         const addRef = await addDoc(collection(db, "beneficiaries"), {
-          accredited_id: Number(formData.get("idNum") as string) || NaN,
+          accredited_id: accredited_id == 0 ? accredited_id : NaN,
           first_name: formData.get("fName") as string,
           last_name: formData.get("lName") as string,
           address: formData.get("address") as string,

--- a/src/routes/ProfileCreation.tsx
+++ b/src/routes/ProfileCreation.tsx
@@ -279,7 +279,7 @@ export function BeneficiaryProfileCreation() {
       <div className="flex items-center justify-center min-h-screen p-4 sm:p-6 bg-[#254151]">
         <div className="relative w-full max-w-2xl flex flex-col items-center rounded-[5px] p-4 sm:p-6">
           <div className="absolute top-0 sm:top-0 z-10 w-28 h-28 sm:w-36 sm:h-36 overflow-hidden bg-gray-500 border-4 border-[#45B29D] rounded-full flex items-center justify-center">
-            <i className="text-[6rem] sm:text-[7rem] text-gray-300 fi fi-ss-circle-user"></i>
+            <i className="flex text-[6rem] sm:text-[7rem] text-gray-300 fi fi-ss-circle-user"></i>
           </div>
           <div className="flex w-full flex-col bg-[#45B29D] rounded-[5px] p-4 pt-20">
             <form className="flex flex-col w-full space-y-3" onSubmit={submitDetails}>

--- a/src/routes/ProfileCreation.tsx
+++ b/src/routes/ProfileCreation.tsx
@@ -192,7 +192,13 @@ export function BeneficiaryProfileCreation() {
   //formState = 1, 1 guardian
   //formState = 2, 2 guardian
   //formState = 3, 3 guardian
-  const [guardianState, setGuardian] = useState(1)
+  const [guardianState, setGuardianState] = useState(1)
+  const [guardians, setGuardians] = useState<Guardian[]>([{
+    name: '',
+    relation: '',
+    email: '',
+    contact_number: ''
+  }])
   const [minimizeState, setMinimize] = useState(false)
 
   function handleMinimize(){
@@ -225,22 +231,15 @@ export function BeneficiaryProfileCreation() {
             formData.get("cNum")?.toString.length
         );
       } else {
-        const role = formData.get("dropdown") as string
-        const guardianEx: Guardian[] = [{
-            name: "string",
-            relation: "string",
-            email: "string@string.com",
-            contact_number: "09876543210"
-        }] // temp
         const addRef = await addDoc(collection(db, "beneficiaries"), {
           accredited_id: Number(formData.get("idNum") as string) || NaN,
           first_name: formData.get("fName") as string,
           last_name: formData.get("lName") as string,
           address: formData.get("address") as string,
-          birthdate: Timestamp.fromMillis(Date.parse(/*formData.get("") as string*/ "2000-01-01T00:00:00.001Z")),
+          birthdate: Timestamp.fromMillis(Date.parse(formData.get("birthdate") as string)),
           grade_level: Number(formData.get("gradelevel") as string),
           is_waitlisted: is_waitlisted,
-          guardians: guardianEx,
+          guardians: guardians,
         });
 
         if(addRef) {
@@ -254,7 +253,13 @@ export function BeneficiaryProfileCreation() {
 
   function handleAdd(){
     if (guardianState+1 <= 3){
-      setGuardian(guardianState+1)
+      setGuardianState(guardianState+1)
+      setGuardians([...guardians, {
+        name: '',
+        relation: '',
+        email: '',
+        contact_number: ''
+      }])
     }
     else
       toast.error("Cannot add more than 3 guardians!")
@@ -262,7 +267,10 @@ export function BeneficiaryProfileCreation() {
 
   function handleSub(){
     if (guardianState-1 >= 1){
-      setGuardian(guardianState-1)
+      setGuardianState(guardianState-1)
+      const reducedGuardians = guardians
+      reducedGuardians.pop()
+      setGuardians(reducedGuardians)
     }
     else
       toast.error("Cannot have 0 guardians!")
@@ -388,7 +396,7 @@ export function BeneficiaryProfileCreation() {
                           (_, i) => (
                             <div className="pb-4">
                               <h3 className="font-[Montserrat] mb-2">Guardian {i + 1}</h3>
-                              <GuardianCard formState={false} />
+                              <GuardianCard formState={false} index={i} guardians={guardians} setGuardians={setGuardians} />
                             </div>
                           )
                         )}

--- a/src/routes/VolunteerProfile.tsx
+++ b/src/routes/VolunteerProfile.tsx
@@ -84,6 +84,10 @@ export function VolunteerProfile() {
         ...volunteer
         })
         setOriginalVolunteer(volunteer)
+        toast.success("Account update success!")
+        setTimeout(function() {
+            location.reload();
+        }, 1000);
     }
 
     return (

--- a/src/routes/VolunteerProfile.tsx
+++ b/src/routes/VolunteerProfile.tsx
@@ -73,14 +73,14 @@ export function VolunteerProfile() {
     const handleSave = 
     async () => {
         setForm(!formState)
-        if(!sex || !contact || !email || !address) {
+        if(!(sex!.toString().trim()) || !(contact!.toString().trim()) || !(email!.toString().trim()) || !(address!.toString().trim())) {
             toast.error("Please fill up all fields!")
             return
         }
         const emailRegEx = new RegExp(
             /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
         ); // from https://emailregex.com/
-        if (!emailRegEx.test(email)) {
+        if (!emailRegEx.test(email!)) {
             toast.error("Please input a proper email!");
             return
         }
@@ -161,7 +161,7 @@ export function VolunteerProfile() {
                         id="bDate"
                         className="w-full text-white border border-[#254151] bg-[#3EA08D] rounded px-3 py-2 font-[Montserrat]"
                         readOnly={formState ?? true}
-                        onChange={(e) => setVolunteer({...volunteer as Volunteer, birthdate : Timestamp.fromDate(birthdate)})}
+                        onChange={(e) => setVolunteer({...volunteer as Volunteer, birthdate : Timestamp.fromMillis(Date.parse(e.target.value))})}
                         value={birthdate?.toISOString().substring(0,10)}/>
                     </div>
 

--- a/src/routes/VolunteerProfile.tsx
+++ b/src/routes/VolunteerProfile.tsx
@@ -77,6 +77,13 @@ export function VolunteerProfile() {
             toast.error("Please fill up all fields!")
             return
         }
+        const emailRegEx = new RegExp(
+            /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
+        ); // from https://emailregex.com/
+        if (!emailRegEx.test(email)) {
+            toast.error("Please input a proper email!");
+            return
+        }
         const updateRef = doc(db, "volunteers", docID!)
         console.log(volunteer)
         try {

--- a/src/routes/VolunteerProfile.tsx
+++ b/src/routes/VolunteerProfile.tsx
@@ -73,7 +73,7 @@ export function VolunteerProfile() {
     const handleSave = 
     async () => {
         setForm(!formState)
-        if(!sex || !contact || email || address)
+        if(!sex || !contact || !email || !address)
         return
         if(sex != "M" && sex != "F")
         return
@@ -107,7 +107,7 @@ export function VolunteerProfile() {
                             </button>
                             <button
                                 className="bg-red-600 hover:bg-red-700 text-white font-semibold px-4 py-2 rounded"
-                                onClick={handleConfirm} // TODO: REPLACE
+                                onClick={handleConfirm}
                             >
                                 Confirm Delete
                             </button>

--- a/src/routes/VolunteerProfile.tsx
+++ b/src/routes/VolunteerProfile.tsx
@@ -73,21 +73,24 @@ export function VolunteerProfile() {
     const handleSave = 
     async () => {
         setForm(!formState)
-        if(!sex || !contact || !email || !address)
-        return
-        if(sex != "M" && sex != "F")
-        return
-
+        if(!sex || !contact || !email || !address) {
+            toast.error("Please fill up all fields!")
+            return
+        }
         const updateRef = doc(db, "volunteers", docID!)
         console.log(volunteer)
-        await updateDoc(updateRef, {
-        ...volunteer
-        })
-        setOriginalVolunteer(volunteer)
-        toast.success("Account update success!")
-        setTimeout(function() {
-            location.reload();
-        }, 1000);
+        try {
+            await updateDoc(updateRef, {
+            ...volunteer
+            })
+            setOriginalVolunteer(volunteer)
+            toast.success("Account update success!")
+            setTimeout(function() {
+                location.reload();
+            }, 1000);
+        } catch {
+            toast.error("Something went wrong")
+        }
     }
 
     return (

--- a/src/routes/YourProfile.tsx
+++ b/src/routes/YourProfile.tsx
@@ -122,7 +122,7 @@ export function YourProfile() {
             )}
             <div className="relative w-full max-w-4xl rounded-md flex flex-col items-center pt-8 pb-10 px-4 sm:px-6 overflow-hidden">
                 <div className="-top-5 sm:-top-20 z-10 w-32 h-32 sm:w-36 sm:h-36 bg-gray-500 border-[5px] border-[#45B29D] rounded-full flex items-center justify-center mb-1">
-                    <i className="text-[6rem] sm:text-[8rem] text-gray-300 fi fi-ss-circle-user"></i>
+                    <i className="flex text-[6rem] sm:text-[8rem] text-gray-300 fi fi-ss-circle-user"></i>
                 </div>
 
             <button

--- a/src/routes/YourProfile.tsx
+++ b/src/routes/YourProfile.tsx
@@ -73,14 +73,14 @@ export function YourProfile() {
     const handleSave = 
     async () => {
         setForm(!formState)
-        if(!sex || !contact || !email || !address) {
+        if(!(sex!.toString().trim()) || !(contact!.toString().trim()) || !(email!.toString().trim()) || !(address!.toString().trim())) {
             toast.error("Please fill up all fields!")
             return
         }
         const emailRegEx = new RegExp(
             /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
         ); // from https://emailregex.com/
-        if (!emailRegEx.test(email)) {
+        if (!emailRegEx.test(email!)) {
             toast.error("Please input a proper email!");
             return
         }

--- a/src/routes/YourProfile.tsx
+++ b/src/routes/YourProfile.tsx
@@ -85,7 +85,9 @@ export function YourProfile() {
         })
         setOriginalVolunteer(volunteer)
         toast.success("Account update success!")
-        location.reload();
+        setTimeout(function() {
+            location.reload();
+        }, 1000);
     }
 
     return (

--- a/src/routes/YourProfile.tsx
+++ b/src/routes/YourProfile.tsx
@@ -77,6 +77,13 @@ export function YourProfile() {
             toast.error("Please fill up all fields!")
             return
         }
+        const emailRegEx = new RegExp(
+            /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
+        ); // from https://emailregex.com/
+        if (!emailRegEx.test(email)) {
+            toast.error("Please input a proper email!");
+            return
+        }
         const updateRef = doc(db, "volunteers", docID!)
         console.log(volunteer)
         try {
@@ -154,7 +161,7 @@ export function YourProfile() {
                         id="bDate"
                         className="w-full text-white border border-[#254151] bg-[#3EA08D] rounded px-3 py-2 font-[Montserrat]"
                         readOnly={formState ?? true}
-                        onChange={(e) => setVolunteer({...volunteer as Volunteer, birthdate : Timestamp.fromDate(birthdate)})}
+                        onChange={(e) => setVolunteer({...volunteer as Volunteer, birthdate : Timestamp.fromMillis(Date.parse(e.target.value))})}
                         value={birthdate?.toISOString().substring(0,10)}/>
                     </div>
 

--- a/src/routes/YourProfile.tsx
+++ b/src/routes/YourProfile.tsx
@@ -107,7 +107,7 @@ export function YourProfile() {
                             </button>
                             <button
                                 className="bg-red-600 hover:bg-red-700 text-white font-semibold px-4 py-2 rounded"
-                                onClick={handleConfirm} // TODO: REPLACE
+                                onClick={handleConfirm}
                             >
                                 Confirm Delete
                             </button>

--- a/src/routes/YourProfile.tsx
+++ b/src/routes/YourProfile.tsx
@@ -73,21 +73,24 @@ export function YourProfile() {
     const handleSave = 
     async () => {
         setForm(!formState)
-        if(!sex || !contact || !email || !address)
-        return
-        if(sex != "M" && sex != "F")
-        return
-
+        if(!sex || !contact || !email || !address) {
+            toast.error("Please fill up all fields!")
+            return
+        }
         const updateRef = doc(db, "volunteers", docID!)
         console.log(volunteer)
-        await updateDoc(updateRef, {
-        ...volunteer
-        })
-        setOriginalVolunteer(volunteer)
-        toast.success("Account update success!")
-        setTimeout(function() {
-            location.reload();
-        }, 1000);
+        try {
+            await updateDoc(updateRef, {
+            ...volunteer
+            })
+            setOriginalVolunteer(volunteer)
+            toast.success("Account update success!")
+            setTimeout(function() {
+                location.reload();
+            }, 1000);
+        } catch {
+            toast.error("Something went wrong")
+        }
     }
 
     return (

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -9,7 +9,7 @@
     "strict": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "lib": ["es2020", "dom"],
+    "lib": ["es2020", "dom", "DOM.Iterable"],
     "types": ["node", "jest", "@testing-library/jest-dom"]
   },
   "include": ["src", "jest.setup.ts"]


### PR DESCRIPTION
Relevant files to test: 
BeneficiaryProfile.tsx
- Added support for guardians (Editing, Adding, Deleting) as well as validation
- changed email regex
- removed check for sex
- Beneficiary ID is hardcoded on line 33, change if necessary*

_*RE: bullet above, as of recent push by @dlpho, it is no longer hard-coded and dependent on the ID in the URL (`.../view-beneficiary/[doc id here]`). if there is no ID in the URL it shows a white page since there's no more route for just `.../view-beneficiary`_

ProfileCreation.tsx (Beneficiary Only)
- Added support for guardians (Editing, Adding, Deleting) as well as validation
- changed email regex
- removed check for sex

also contact number is string now, format is 09... not 639...

other files modified & functionalities:
- GuardianCard.tsx (to handle guardians)
- both volunteer view files (toast errors, removed check for Sex)
- delete was added for both beneficiaries & volunteers, but currently this only adds a time to live field (curr time + 30 days in millis)